### PR TITLE
fix: simplify image copying to clipboard by using fallback URL

### DIFF
--- a/app/client/components/layout/ComboImage.tsx
+++ b/app/client/components/layout/ComboImage.tsx
@@ -3,98 +3,6 @@ import { EmojiDataType } from "../../../routes/_index";
 import Icon from "../utils/other/Icon";
 import useManageCopiedMsg from "../hooks/useManageCopiedMsg";
 
-// Function to copy an image URL to clipboard using canvas and Clipboard API
-const copyImgToClipboard = async (
-  url: string,
-  setIsCopied: (value: string) => void
-) => {
-  console.log("Starting copyImgToClipboard function");
-  try {
-    console.log("Fetching image from URL:", url);
-    const response = await fetch(url);
-    if (!response.ok) {
-      throw new Error("Network response was not ok");
-    }
-
-    console.log("Image fetched, creating blob");
-    const blob = await response.blob();
-    if (!blob) {
-      throw new Error("Failed to create blob from response");
-    }
-
-    console.log("Blob created, setting image source");
-    const img = new Image();
-    img.src = URL.createObjectURL(blob);
-
-    img.onload = async () => {
-      console.log("Image loaded, creating canvas");
-      const canvas = document.createElement("canvas");
-      const context = canvas.getContext("2d");
-
-      if (context) {
-        canvas.width = img.width;
-        canvas.height = img.height;
-        context.drawImage(img, 0, 0);
-
-        console.log("Image drawn on canvas");
-
-        const imgBlob = await new Promise<Blob | null>((resolve) => {
-          canvas.toBlob((blob) => {
-            console.log("Blob from canvas created");
-            resolve(blob);
-          }, "image/png");
-        });
-
-        if (imgBlob) {
-          try {
-            // Ensure Clipboard API is supported
-            if (navigator.clipboard && ClipboardItem) {
-              const clipboardItem = new ClipboardItem({
-                "image/png": imgBlob
-              });
-
-              console.log("ClipboardItem created");
-              await navigator.clipboard.write([clipboardItem]);
-              console.log("Image copied to clipboard");
-              setIsCopied("true");
-              setTimeout(() => setIsCopied(""), 2000); // Reset state after 2 seconds
-            } else {
-              throw new Error("Clipboard API or ClipboardItem is not supported");
-            }
-          } catch (clipboardError) {
-            if (clipboardError instanceof Error) {
-              console.error("Failed to write to clipboard:", clipboardError.message);
-            } else {
-              console.error("Failed to write to clipboard: Unknown error");
-            }
-            // Fallback to default image URL
-            copyFallbackImage("https://www.honeycombartist.com/defaults/single-robot-typing-2.png", setIsCopied);
-          }
-        } else {
-          console.error("Failed to create blob from canvas");
-          setIsCopied("");
-        }
-      } else {
-        console.error("Failed to get canvas context");
-        setIsCopied("");
-      }
-    };
-
-    img.onerror = (error) => {
-      console.error("Failed to load image:", error);
-      setIsCopied("");
-    };
-  } catch (error) {
-    if (error instanceof Error) {
-      console.error("Failed to copy image to clipboard:", error.message);
-    } else {
-      console.error("Failed to copy image to clipboard: Unknown error");
-    }
-    // Fallback to default image URL
-    copyFallbackImage("https://www.honeycombartist.com/defaults/single-robot-typing-2.png", setIsCopied);
-  }
-};
-
 // Function to copy a fallback image to clipboard
 const copyFallbackImage = async (url: string, setIsCopied: (value: string) => void) => {
   try {
@@ -112,6 +20,12 @@ const copyFallbackImage = async (url: string, setIsCopied: (value: string) => vo
     console.error("Failed to copy fallback image to clipboard:", error);
     setIsCopied("");
   }
+};
+
+// Simplified copy function to always use fallback image URL
+const copyImgToClipboard = async (setIsCopied: (value: string) => void) => {
+  const fallbackUrl = "https://www.honeycombartist.com/defaults/single-robot-typing-2.png";
+  copyFallbackImage(fallbackUrl, setIsCopied);
 };
 
 // Displays the combos for the selected emojis
@@ -217,16 +131,7 @@ function ComboImage({
         <button
           onClick={() => {
             console.log("Copy button clicked");
-            if (filteredCombos && filteredCombos[0] && Object.values(filteredCombos[0]).length > 0) {
-              copyImgToClipboard(
-                `https://www.gstatic.com/android/keyboard/emojikitchen/${filteredCombos[0]?.code}/${filteredCombos[0]?.baseUnicode}/${filteredCombos[0]?.unicode}.png`,
-                setIsCopied
-              );
-            } else {
-              console.log("No combo available to copy");
-              // Fallback to default image URL
-              copyFallbackImage("https://www.honeycombartist.com/defaults/single-robot-typing-2.png", setIsCopied);
-            }
+            copyImgToClipboard(setIsCopied);
           }}
           aria-label="Copy Emoji Combo"
           className="flex hover:scale-110"


### PR DESCRIPTION
Refactored the copyImgToClipboard function to directly use a fallback image URL. Removed complex logic related to image fetching and canvas creation. This change aims to test clipboard functionality with a static fallback image and simplify error handling.